### PR TITLE
[WIP] Fix for weird wrong number of arguments bug

### DIFF
--- a/app-ios/chaining_controller.rb
+++ b/app-ios/chaining_controller.rb
@@ -1,0 +1,22 @@
+class ChainingController < UIViewController
+  attr :login_button
+  attr :username_field
+  attr :password_field
+
+  def loadView
+    super
+
+    @username_field = UITextField.new
+    @password_field = UITextField.new
+
+    @login_button = UIButton.buttonWithType(UIButtonTypeRoundedRect)
+    @login_button.accessibilityLabel = 'login_button'
+    @login_button.setTitle('login_button', forState: UIControlStateNormal)
+    @login_button.sizeToFit
+    @login_button.center = [view.frame.size.width / 2, view.frame.size.height / 2 + 50]
+
+    view.addSubview @login_button
+    view.addSubview @username_field
+    view.addSubview @password_field
+  end
+end

--- a/lib/motion-wiretap/all/wiretap.rb
+++ b/lib/motion-wiretap/all/wiretap.rb
@@ -80,10 +80,6 @@ module MotionWiretap
       end
 
       @listener_handlers.each do |block_or_wiretap|
-        p 'triggering changed:'
-        p block_or_wiretap.class
-        p 'with values:'
-        p values
         trigger_changed_on(block_or_wiretap, values)
       end
 
@@ -92,10 +88,6 @@ module MotionWiretap
 
     # Sends the block or wiretap a changed signal
     def trigger_changed_on(block_or_wiretap, values)
-      p 'triggering changed on:'
-      p block_or_wiretap.class
-      p 'with values:'
-      p values
       if block_or_wiretap.is_a? Wiretap
         block_or_wiretap.trigger_changed(*values)
       else
@@ -348,11 +340,6 @@ module MotionWiretap
       super()
     end
 
-    def trigger_changed(*values)
-      p 'super called in child'
-      super
-    end
-
     def teardown
       @parent.cancel!
       super
@@ -370,19 +357,9 @@ module MotionWiretap
     # passes the values through the filter before passing up to the parent
     # implementation
     def trigger_changed(*values)
-      p 'calling trigger_changed on wiretap filter'
-      p 'with values:'
-      p values
-      p 'with block arity:'
-      p @filter.arity
       if @filter.call(*values)
-        p 'block returns true'
-        p 'calling super with arguments'
-        p values
         Wiretap.instance_method(:trigger_changed).bind(self).call(*values)
         # super
-      else
-        p 'block returns false'
       end
     end
 

--- a/lib/motion-wiretap/all/wiretap.rb
+++ b/lib/motion-wiretap/all/wiretap.rb
@@ -375,7 +375,7 @@ module MotionWiretap
     # passes the values through the combiner before passing up to the parent
     # implementation
     def trigger_changed(*values)
-      super(@combiner.call(*values))
+      Wiretap.instance_method(:trigger_changed).bind(self).call(@combiner.call(*values))
     end
 
   end
@@ -391,7 +391,7 @@ module MotionWiretap
     # passes each value through the @reducer, passing in the return value of the
     # previous call (starting with @memo)
     def trigger_changed(*values)
-      super(values.inject(@memo, &@reducer))
+      Wiretap.instance_method(:trigger_changed).bind(self).call(values.inject(@memo, &@reducer))
     end
 
   end
@@ -406,7 +406,7 @@ module MotionWiretap
     # passes the values through the mapper before passing up to the parent
     # implementation
     def trigger_changed(*values)
-      super(*values.map { |value| @mapper.call(value) })
+      Wiretap.instance_method(:trigger_changed).bind(self).call(*values.map { |value| @mapper.call(value) })
     end
 
   end

--- a/lib/motion-wiretap/all/wiretap.rb
+++ b/lib/motion-wiretap/all/wiretap.rb
@@ -80,6 +80,10 @@ module MotionWiretap
       end
 
       @listener_handlers.each do |block_or_wiretap|
+        p 'triggering changed:'
+        p block_or_wiretap.class
+        p 'with values:'
+        p values
         trigger_changed_on(block_or_wiretap, values)
       end
 
@@ -88,6 +92,10 @@ module MotionWiretap
 
     # Sends the block or wiretap a changed signal
     def trigger_changed_on(block_or_wiretap, values)
+      p 'triggering changed on:'
+      p block_or_wiretap.class
+      p 'with values:'
+      p values
       if block_or_wiretap.is_a? Wiretap
         block_or_wiretap.trigger_changed(*values)
       else
@@ -340,6 +348,11 @@ module MotionWiretap
       super()
     end
 
+    def trigger_changed(*values)
+      p 'super called in child'
+      super
+    end
+
     def teardown
       @parent.cancel!
       super
@@ -357,8 +370,19 @@ module MotionWiretap
     # passes the values through the filter before passing up to the parent
     # implementation
     def trigger_changed(*values)
+      p 'calling trigger_changed on wiretap filter'
+      p 'with values:'
+      p values
+      p 'with block arity:'
+      p @filter.arity
       if @filter.call(*values)
-        super(*values)
+        p 'block returns true'
+        p 'calling super with arguments'
+        p values
+        Wiretap.instance_method(:trigger_changed).bind(self).call(*values)
+        # super
+      else
+        p 'block returns false'
       end
     end
 

--- a/spec/ios/long_chaining_spec.rb
+++ b/spec/ios/long_chaining_spec.rb
@@ -47,7 +47,7 @@ describe "MotionWiretap with lots of chaining" do
     if @touched
       test.call
     else
-      print "\nyou have 5 seconds to tap 'control_event_button'"
+      print "\nyou have 5 seconds to tap 'login_button'"
       wait 5, &test
     end
   end

--- a/spec/ios/long_chaining_spec.rb
+++ b/spec/ios/long_chaining_spec.rb
@@ -1,0 +1,47 @@
+describe "MotionWiretap with lots of chaining" do
+
+  before do
+    @login_button = UIButton.buttonWithType(UIButtonTypeRoundedRect)
+    @username_field = UITextField.new
+    @password_field = UITextField.new
+
+    # i don't want to set the value of @login_button.enabled, but we need to
+    # have the method compiled.
+    UIButton.new.enabled = true
+
+    @done = false
+    @login_enabled_signal = 
+      MW([
+        MW(@username_field, :text),
+        MW(@password_field, :text)
+      ])
+      .combine do |username, password|
+        username && password && username.length > 0 && password.length > 0
+      end
+
+    @do_login_signal = 
+      MW([@login_enabled_signal, MW(@login_button).on(:touch)])
+      .combine { |enabled, touched| enabled && touched }
+      .filter { |doing| doing }
+      .listen do |doing|
+        @done = true
+      end
+  end
+
+  after do
+    @login_enabled_signal.cancel!
+    @do_login_signal.cancel!
+  end
+
+  it "should start with undone" do
+    @done.should == false
+  end
+
+  it "it should be done when all is ready" do
+    @username_field.text = 'username'
+    @password_field.text = 'password'
+    tap @login_button
+    @done.should == true
+  end
+
+end


### PR DESCRIPTION
This is my humble attempt at #9 - it's far from finished but makes it work for
my current use case. Anyways, I started with a spec that includes my code that
caused the bug, and went from there... The problem area in this case is in this
block of code:

``` ruby
class WiretapFilter < WiretapChild

  # ...

  def trigger_changed(*values)
    if @filter.call(*values)
      super(*values)
    end
  end

end
```

Where `super(*values)` seems to have forgotten the arity of
`Wiretap::trigger_changed`. After many iterations, the only thing that seems to
work is:

``` ruby
Wiretap.instance_method(:trigger_changed).bind(self).call(*values)
```

It's super ugly but works for me... Definitely a RM bug, might be related to
this?: http://hipbyte.myjetbrains.com/youtrack/issue/RM-486

Also I find it weird that this isn't happening on the other `WiretapChild`'s
(combiner, reducer) etc.. maybe its just chance that it hasn't occured with them
yet.

Any opinions?
