### PR TITLE
False positive specs + some other things up for discussion

### DIFF
--- a/spec/ios/nsarray_spec.rb
+++ b/spec/ios/nsarray_spec.rb
@@ -193,6 +193,24 @@ describe MotionWiretap::WiretapArray do
         @reduced.should == 'name 1 name 2'
       end
 
+      it "should reduce with an initial value" do
+        p1 = Person.new
+
+        Motion.wiretap(p1, :name)
+        .reduce(3) do |memo, name|
+          memo + (name || 0)
+        end.listen do |reduced|
+          @reduced = reduced
+        end
+
+        p1.name = 1
+        @reduced.should == 4
+        p1.name = 2
+        @reduced.should == 6
+        p1.name = 3
+        @reduced.should == 9
+      end
+
       it "should reduce a mix of Wiretap and non-Wiretap objects" do
         p1 = Person.new
         Motion.wiretap([

--- a/spec/ios/nsarray_spec.rb
+++ b/spec/ios/nsarray_spec.rb
@@ -119,9 +119,14 @@ describe MotionWiretap::WiretapArray do
     end
 
     describe "should reduce the values" do
+      before do
+        @reduced = nil
+      end
+
       it "should reduce Wiretap objects" do
         p1 = Person.new
         p2 = Person.new
+
         Motion.wiretap([
           Motion.wiretap(p1, :name),
           Motion.wiretap(p2, :name),
@@ -134,6 +139,7 @@ describe MotionWiretap::WiretapArray do
         end.listen do |reduced|
           @reduced = reduced
         end
+
         p1.name = 'name 1'
         @reduced.should == 'name 1'
         p2.name = 'name 2'
@@ -190,6 +196,7 @@ describe MotionWiretap::WiretapArray do
         end.listen do |reduced|
           @reduced = reduced
         end
+
         @reduced.should == 'name 1 name 2'
       end
 
@@ -231,6 +238,10 @@ describe MotionWiretap::WiretapArray do
     end
 
     describe "should map the values" do
+      before do
+        @mapped = nil
+      end
+
       it "should map Wiretap objects" do
         p1 = Person.new
         p2 = Person.new


### PR DESCRIPTION
Heya, I'm using wiretap in a new app build (hence why so many PR's!)

First thing - I realized that `reduce()` wasn't actually keeping a memo
properly (see spec I added)

Second - there are some false positive specs because `@reduced` or `@mapped`
is never reset before each test, after resetting them there are a couple of failed
specs regarding the use of non-callbacky values for `WiretapArray`. I propose that
we store these values somewhere and trigger with them whenever new listeners get added

Third - I didn't think that it made sense to re-trigger every stream in a set whenever
a single stream changes for a `WiretapArray::reduce()` since the reduce block can only deal with a single
value at a time, it's implied that it merges multiple streams into one. So I added the ability
to pass an index into `trigger_changed(*values, index)`, now `WiretapChild`'s can decide independently
how they want to deal with the change values (either reducing or mapping)
